### PR TITLE
ci: 릴리스를 Actions 버튼으로 — 태그·Release·퍼지·실물 검증까지

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: release
+
+# 릴리스를 버튼 하나로. Actions 탭 → release → "Run workflow" → 버전 입력.
+# 태그 생성 권한이 없는 환경(로컬 터미널이 없을 때·에이전트 세션)에서도 낼 수 있게 하려는 것이 목적이다.
+# 로컬에서 낼 때는 AGENTS.md 대로 `node scripts/release.js --apply` 를 쓰면 된다 — 같은 검사를 공유한다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "내보낼 버전 — CHANGELOG 최상단과 같아야 한다 (예: v0.19.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write # 태그·릴리스 생성
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 태그 조회에 전체 히스토리가 필요하다
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 1) 낼 수 있는 상태인가 — 입력 버전 = CHANGELOG 최상단 = 문서 CDN 태그
+      #    (입력값은 셸에 직접 끼워 넣지 않는다 — env 로 넘겨 인젝션을 막는다)
+      - name: 버전 정합 (입력 = CHANGELOG 최상단 = 문서 CDN 태그)
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node scripts/release.js --pre --expect "$VERSION"
+
+      - name: 이미 나간 버전인지
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "::error::$VERSION 태그가 이미 있다 — 이미 릴리스된 버전이다"
+            exit 1
+          fi
+          echo "$VERSION 미출시 확인"
+
+      # 2) 통과해야만 나간다 — ci.yml 과 같은 3종
+      - name: lint
+        run: node tests/lint.js
+      - name: playwright 설치
+        run: |
+          npm init -y > /dev/null
+          npm i playwright > /dev/null
+          npx playwright install --with-deps chromium
+      - name: e2e 회귀
+        run: node tests/e2e.js
+      - name: smoke
+        run: node tests/smoke.js
+
+      # 3) 태그 + 릴리스 (gh 가 태그를 target 커밋에 만들어 준다)
+      - name: GitHub Release 발행
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          node scripts/release.js --notes > /tmp/notes.md
+          echo "--- 릴리스 본문 ---"; cat /tmp/notes.md
+          gh release create "$VERSION" --title "$VERSION" --notes-file /tmp/notes.md --target "$GITHUB_SHA"
+
+      # 4) 퍼지 — 태그가 생긴 뒤라야 의미가 있다. @0 별칭이 특히 늦게 따라온다
+      - name: jsDelivr 퍼지
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          for t in "$VERSION" "0"; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" \
+              "https://purge.jsdelivr.net/gh/charmisuk/screenspec@$t/screenspec.js")
+            echo "@$t 퍼지 → HTTP $code"
+          done
+
+      # 5) 진짜 나갔는지 확인 — 고정 태그 200 · @0 재해석 · 문서가 시키는 주소가 열리는가
+      - name: 실물 검증
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node scripts/release.js --verify --expect "$VERSION"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 | `tests/e2e.js` | Playwright 브라우저 회귀 |
 | `tests/smoke.js` | 예제 전수 클릭 스모크 (아무거나 눌러도 안 죽는가) |
 | `scripts/release.js` | 릴리스 — 태그·푸시·퍼지·실물 확인 (문서가 미출시 태그를 가리키는지 검사) |
+| `.github/workflows/release.yml` | 릴리스를 Actions 버튼으로 (같은 검사를 release.js 와 공유) |
 | `scripts/backlog-sync.js` | GitHub 이슈 ↔ Notion 보드 싱크 검사 (로컬 전용) |
 | `docs/sprint/` | 이슈 사이클 작업 기록 (tasks.json·회고) — 내부 로그, 라이브러리 동작과 무관 |
 
@@ -58,14 +59,20 @@ node scripts/backlog-sync.js --apply   # 노션 쪽을 맞추고 실행 후 자�
 1. lint·e2e·smoke 통과 확인
 2. `CHANGELOG.md`에 항목 추가 (최상단 `## vX.Y.Z`)
 3. 버전 문자열 갱신: `screenspec.js` 헤더·배지, `README.md`·`SKILL.md`의 `@vX.Y.Z`
-4. commit → **main 에 올린 뒤** 아래를 돌린다
+4. commit → **main 에 올린 뒤** 둘 중 하나로 내보낸다
+
+**A. Actions 버튼** (터미널 없이 · 태그 푸시 권한이 없는 환경에서도)
+Actions 탭 → **release** → *Run workflow* → 버전(`vX.Y.Z`) 입력.
+버전 정합 → lint·e2e·smoke → 태그+Release 발행 → 퍼지 → 실물 검증까지 한 번에 돈다.
+
+**B. 로컬**
 
 ```bash
 node scripts/release.js           # 검사만 — 나갈 준비가 됐는지
 node scripts/release.js --apply   # 태그 → 푸시 → jsDelivr 퍼지 → 실물 확인
 ```
 
-5. 스크립트가 마지막에 출력하는 `gh release create vX.Y.Z` 를 실행 (본문은 같이 출력되는 CHANGELOG 절)
+5. B 로 냈다면 스크립트가 마지막에 출력하는 `gh release create vX.Y.Z` 를 실행 (본문은 같이 출력되는 CHANGELOG 절). A 는 이 단계까지 자동이다
 
 > **버전 문자열만 올리고 태그를 만들지 않으면 안 된다.** 그 순간 README·SKILL 이 존재하지 않는 CDN 주소(`@vX.Y.Z` → 404)를 가리키고,
 > 그 주소를 심은 프로토타입은 조용히 아무것도 안 뜬다. lint 는 이걸 못 잡는다 — 헤더·배지·CHANGELOG·문서 태그가 *서로 같은지*만 보지

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,8 +1,12 @@
 /*
- * 릴리스 — 태그 → 푸시 → jsDelivr 퍼지 → 실물 검증을 한 번에.
+ * 릴리스 — 태그 → 푸시 → jsDelivr 퍼지 → 실물 확인을 한 번에.
  *
- *   node scripts/release.js            검사만 (기본 = dry-run). 나갈 준비가 됐는지 보고
- *   node scripts/release.js --apply    실제로 태그·푸시·퍼지하고 결과를 확인
+ *   node scripts/release.js                  검사만 (기본 = dry-run). 나갈 준비가 됐는지
+ *   node scripts/release.js --apply          로컬에서 실제로 태그·푸시·퍼지하고 결과를 확인
+ *   node scripts/release.js --notes          CHANGELOG 최상단 절만 출력 (릴리스 본문용)
+ *   node scripts/release.js --pre            버전 정합만 확인 (태그 없어도 통과 — 릴리스 직전 CI 용)
+ *   node scripts/release.js --verify         실물만 확인 (git 상태 검사 없음 — CI 용)
+ *   node scripts/release.js --expect v0.19.3 넘긴 버전이 CHANGELOG·문서와 같은지 확인 (다른 모드와 겸용)
  *
  * 왜 스크립트인가 (2026-08-25 사고):
  *   버전 문자열만 올리고 태그를 안 만들면 README·SKILL 이 존재하지 않는 CDN 주소를 가리킨다.
@@ -11,9 +15,9 @@
  *   (의존성 0 정적 검사라 네트워크를 쓰지 않는다). 그 구멍을 여기서 막는다.
  *
  * 잡는 것:
- *   1) main 의 문서가 미출시 태그를 가리킴      → 사용자가 404 를 심게 된다
- *   2) 태그는 있는데 CDN 이 옛 내용을 물고 있음   → 퍼지 누락
- *   3) 작업 트리가 더럽거나 main 이 아님          → 엉뚱한 커밋에 태그가 박힌다
+ *   1) main 의 문서가 미출시 태그를 가리킴        → 사용자가 404 를 심게 된다
+ *   2) 태그는 있는데 CDN 이 옛 내용을 물고 있음     → 퍼지 누락 (@0 별칭이 특히 늦다)
+ *   3) 작업 트리가 더럽거나 main 이 아님            → 엉뚱한 커밋에 태그가 박힌다
  */
 const fs = require("fs");
 const path = require("path");
@@ -22,7 +26,14 @@ const { execSync } = require("child_process");
 const REPO = path.resolve(__dirname, "..");
 const GH_REPO = "charmisuk/screenspec";
 const CDN = (tag) => `https://cdn.jsdelivr.net/gh/${GH_REPO}@${tag}/screenspec.js`;
-const APPLY = process.argv.includes("--apply");
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const APPLY = has("--apply");
+const VERIFY = has("--verify"); /* CI: 체크아웃이 detached 라 git 상태 검사를 건너뛴다 */
+const NOTES = has("--notes");
+const PRE = has("--pre"); /* 릴리스 직전: 버전 정합만. 태그는 아직 없는 게 정상이다 */
+const EXPECT = argv[argv.indexOf("--expect") + 1] && has("--expect") ? argv[argv.indexOf("--expect") + 1] : null;
 
 let bad = 0;
 const ok = (m) => console.log("  ✓ " + m);
@@ -50,49 +61,82 @@ async function until(label, fn, tries = 8, gap = 5000) {
   return null;
 }
 
+/* ---- 버전은 CHANGELOG 최상단이 원본, 문서 CDN 태그가 그 사본 ---- */
+const changelog = fs.readFileSync(path.join(REPO, "CHANGELOG.md"), "utf8");
+const version = (changelog.match(/^## v(\d+\.\d+\.\d+)/m) || [])[1];
+if (!version) die("CHANGELOG.md 최상단에서 '## vX.Y.Z' 를 찾지 못했다");
+const tag = "v" + version;
+
+if (NOTES) { console.log((changelog.split(/^## /m)[1] || "").split("\n").slice(1).join("\n").trim()); process.exit(0); }
+
+const docTags = new Set();
+for (const f of ["README.md", "SKILL.md"]) {
+  const d = fs.readFileSync(path.join(REPO, f), "utf8");
+  [...d.matchAll(/@v(\d+\.\d+\.\d+)/g)].forEach((m) => docTags.add(m[1]));
+}
+
 (async () => {
-  console.log("[릴리스] " + (APPLY ? "실행 (--apply)" : "검사만 — 실제로 내보내려면 --apply"));
+  console.log("[릴리스] " + (APPLY ? "실행 (--apply)" : VERIFY ? "실물 확인 (--verify)" : PRE ? "버전 정합 (--pre)" : "검사만 — 실제로 내보내려면 --apply"));
 
-  /* ---- 1. 나갈 수 있는 상태인가 ---- */
-  console.log("\n작업 상태");
-  const branch = git("rev-parse --abbrev-ref HEAD");
-  const dirty = git("status --porcelain");
-  branch === "main" ? ok("브랜치 main") : no(`브랜치가 main 이 아니다 (${branch}) — 릴리스는 main 에서만`);
-  dirty ? no("작업 트리에 커밋 안 된 변경이 있다\n" + dirty) : ok("작업 트리 깨끗");
+  /* ---- 1. 나갈 수 있는 상태인가 (CI 는 건너뛴다) ---- */
+  if (!VERIFY && !PRE) {
+    console.log("\n작업 상태");
+    const branch = git("rev-parse --abbrev-ref HEAD");
+    const dirty = git("status --porcelain");
+    branch === "main" ? ok("브랜치 main") : no(`브랜치가 main 이 아니다 (${branch}) — 릴리스는 main 에서만`);
+    dirty ? no("작업 트리에 커밋 안 된 변경이 있다\n" + dirty) : ok("작업 트리 깨끗");
 
-  try { execSync("node tests/lint.js", { cwd: REPO, stdio: "pipe" }); ok("lint 통과"); }
-  catch { no("lint 실패 — node tests/lint.js 먼저 통과시켜라"); }
-  console.log("    (e2e·smoke 는 브라우저가 필요해 여기서 돌리지 않는다 — AGENTS.md 절차대로 미리 돌려라)");
+    try { execSync("node tests/lint.js", { cwd: REPO, stdio: "pipe" }); ok("lint 통과"); }
+    catch { no("lint 실패 — node tests/lint.js 먼저 통과시켜라"); }
+    console.log("    (e2e·smoke 는 브라우저가 필요해 여기서 돌리지 않는다 — AGENTS.md 절차대로 미리 돌려라)");
+  }
 
   /* ---- 2. 무슨 버전을 내보내는가 ---- */
-  const changelog = fs.readFileSync(path.join(REPO, "CHANGELOG.md"), "utf8");
-  const version = (changelog.match(/^## v(\d+\.\d+\.\d+)/m) || [])[1];
-  if (!version) die("CHANGELOG.md 최상단에서 '## vX.Y.Z' 를 찾지 못했다");
-  const tag = "v" + version;
-
-  /* 문서가 가리키는 고정 태그 — 이게 이번 사고의 핵심이다 */
-  const docTags = new Set();
-  for (const f of ["README.md", "SKILL.md"]) {
-    const d = fs.readFileSync(path.join(REPO, f), "utf8");
-    [...d.matchAll(/@v(\d+\.\d+\.\d+)/g)].forEach((m) => docTags.add(m[1]));
-  }
   console.log("\n버전");
   ok(`CHANGELOG 최상단 ${tag}`);
   docTags.size === 1 && docTags.has(version)
     ? ok(`문서 CDN 태그도 ${tag}`)
     : no(`문서 CDN 태그가 어긋난다: ${JSON.stringify([...docTags])} vs ${version}`);
+  if (EXPECT) {
+    EXPECT === tag ? ok(`요청한 버전 ${EXPECT} 일치`)
+                   : no(`요청한 버전 ${EXPECT} 이 CHANGELOG 최상단(${tag})과 다르다 — CHANGELOG 를 먼저 올려라`);
+  }
+
+  if (PRE) {
+    console.log("\n결과: " + (bad ? `문제 ${bad}건` : "버전 정합 이상 없음 — 태그는 릴리스 단계에서 만든다"));
+    process.exit(bad ? 1 : 0);
+  }
 
   const tagged = git(`ls-remote --tags origin ${tag}`).length > 0;
   if (tagged) ok(`원격에 ${tag} 태그 있음 (이미 릴리스)`);
   else if (APPLY) ok(`원격에 ${tag} 없음 → 지금 만든다`);
   else no(`원격에 ${tag} 태그가 없다 — 문서는 ${tag} 를 가리키는데 그 주소는 404 다. --apply 로 릴리스하거나 문서 태그를 되돌려라`);
 
+  /* ---- 3. 실물 확인 (검사 모드·CI 모드) ---- */
   if (!APPLY) {
-    /* 이미 릴리스된 상태라면 실물이 살아 있는지까지 본다 */
     if (tagged) {
       console.log("\n실물 확인");
-      const r = await fetchLib(CDN(tag));
-      r.status === 200 ? ok(`${tag} 200 (헤더 v${r.ver})`) : no(`${tag} → HTTP ${r.status} — 퍼지가 필요하다`);
+      const major = version.split(".").slice(0, 2).join(".");
+      const pinned = await until(`${tag} 반영`, async () => {
+        const r = await fetchLib(CDN(tag));
+        return r.status === 200 && r.ver === major ? r : null;
+      }, VERIFY ? 8 : 1);
+      pinned ? ok(`${tag} 200 · 헤더 v${pinned.ver}`) : no(`${tag} 가 아직 안 뜬다`);
+
+      if (VERIFY) {
+        const alias = await until("@0 재해석", async () => {
+          try {
+            const r = await fetch(`https://data.jsdelivr.com/v1/packages/gh/${GH_REPO}/resolved?specifier=0`);
+            const j = await r.json();
+            return j.version === version ? j.version : null;
+          } catch { return null; }
+        });
+        alias ? ok(`@0 → ${alias}`) : no(`@0 가 아직 ${version} 로 안 간다 — 퍼지 후 지연일 수 있다`);
+        for (const t of docTags) {
+          const r = await fetchLib(CDN("v" + t));
+          r.status === 200 ? ok(`문서의 @v${t} 열림`) : no(`문서가 가리키는 @v${t} → HTTP ${r.status}`);
+        }
+      }
     }
     console.log("\n결과: " + (bad ? `문제 ${bad}건` : "이상 없음"));
     process.exit(bad ? 1 : 0);
@@ -100,46 +144,18 @@ async function until(label, fn, tries = 8, gap = 5000) {
 
   if (bad) die(`문제 ${bad}건 — 고치고 다시 실행해라 (태그는 만들지 않았다)`);
 
-  /* ---- 3. 태그 · 푸시 ---- */
+  /* ---- 4. 태그 · 푸시 ---- */
   console.log("\n태그·푸시");
   if (!tagged) { git(`tag ${tag}`); ok(`태그 ${tag} 생성`); }
   git("push origin main --tags");
   ok("origin/main + 태그 푸시");
 
-  /* ---- 4. 퍼지 — 태그가 생긴 뒤라야 의미가 있다 ---- */
-  console.log("\njsDelivr 퍼지");
-  for (const t of [tag, "0"]) {
-    const u = `https://purge.jsdelivr.net/gh/${GH_REPO}@${t}/screenspec.js`;
-    try { const r = await fetch(u); ok(`@${t} 퍼지 요청 (HTTP ${r.status})`); }
-    catch (e) { no(`@${t} 퍼지 실패 — ${e.message}`); }
-  }
+  /* ---- 5. 퍼지 — 태그가 생긴 뒤라야 의미가 있다 ---- */
+  await purge();
 
-  /* ---- 5. 실제로 나갔는지 확인 (여기가 이 스크립트의 존재 이유) ---- */
-  console.log("\n검증");
-  const major = version.split(".").slice(0, 2).join(".");
+  /* ---- 6. 실제로 나갔는지 확인 ---- */
+  await verifyLive();
 
-  const pinned = await until(`${tag} 반영`, async () => {
-    const r = await fetchLib(CDN(tag));
-    return r.status === 200 && r.ver === major ? r : null;
-  });
-  pinned ? ok(`${tag} 200 · 헤더 v${pinned.ver}`) : no(`${tag} 가 아직 안 뜬다 — 잠시 후 다시 확인해라`);
-
-  const alias = await until("@0 재해석", async () => {
-    try {
-      const r = await fetch(`https://data.jsdelivr.com/v1/packages/gh/${GH_REPO}/resolved?specifier=0`);
-      const j = await r.json();
-      return j.version === version ? j.version : null;
-    } catch { return null; }
-  });
-  alias ? ok(`@0 → ${alias}`) : no(`@0 가 아직 ${version} 로 안 간다 — 퍼지 후 지연일 수 있다`);
-
-  /* 문서가 시키는 주소가 진짜 열리는가 — 이 검사가 없어서 404 를 문서에 실을 뻔했다 */
-  for (const t of docTags) {
-    const r = await fetchLib(CDN("v" + t));
-    r.status === 200 ? ok(`문서의 @v${t} 열림`) : no(`문서가 가리키는 @v${t} → HTTP ${r.status}`);
-  }
-
-  /* ---- 6. 남은 수동 절차 ---- */
   const notes = (changelog.split(/^## /m)[1] || "").trim();
   console.log("\n남은 절차 — GitHub Release (본문은 아래 CHANGELOG 절)");
   console.log(`  gh release create ${tag} --title "${tag}" --notes-file <파일>`);
@@ -147,4 +163,37 @@ async function until(label, fn, tries = 8, gap = 5000) {
 
   console.log("\n결과: " + (bad ? `릴리스는 했으나 확인 ${bad}건 실패` : `${tag} 릴리스 완료`));
   process.exit(bad ? 1 : 0);
+
+  async function purge() {
+    console.log("\njsDelivr 퍼지");
+    for (const t of [tag, "0"]) {
+      const u = `https://purge.jsdelivr.net/gh/${GH_REPO}@${t}/screenspec.js`;
+      try { const r = await fetch(u); ok(`@${t} 퍼지 요청 (HTTP ${r.status})`); }
+      catch (e) { no(`@${t} 퍼지 실패 — ${e.message}`); }
+    }
+  }
+  async function verifyLive() {
+    console.log("\n검증");
+    const major = version.split(".").slice(0, 2).join(".");
+    const pinned = await until(`${tag} 반영`, async () => {
+      const r = await fetchLib(CDN(tag));
+      return r.status === 200 && r.ver === major ? r : null;
+    });
+    pinned ? ok(`${tag} 200 · 헤더 v${pinned.ver}`) : no(`${tag} 가 아직 안 뜬다 — 잠시 후 다시 확인해라`);
+
+    const alias = await until("@0 재해석", async () => {
+      try {
+        const r = await fetch(`https://data.jsdelivr.com/v1/packages/gh/${GH_REPO}/resolved?specifier=0`);
+        const j = await r.json();
+        return j.version === version ? j.version : null;
+      } catch { return null; }
+    });
+    alias ? ok(`@0 → ${alias}`) : no(`@0 가 아직 ${version} 로 안 간다 — 퍼지 후 지연일 수 있다`);
+
+    /* 문서가 시키는 주소가 진짜 열리는가 — 이 검사가 없어서 404 를 문서에 실을 뻔했다 */
+    for (const t of docTags) {
+      const r = await fetchLib(CDN("v" + t));
+      r.status === 200 ? ok(`문서의 @v${t} 열림`) : no(`문서가 가리키는 @v${t} → HTTP ${r.status}`);
+    }
+  }
 })();


### PR DESCRIPTION
v0.19.2 를 내면서 겪은 두 가지를 자동화한다 — 태그를 만들 권한이 없어 릴리스가 멈췄던 것, 그리고 태그를 만든 뒤 `@0` 별칭이 옛 파일을 계속 주던 것(퍼지 누락).

## 무엇이 달라지나

**Actions 탭 → `release` → Run workflow → 버전 입력.** 끝이다. 터미널도, 태그 푸시 권한도 필요 없다. 모바일에서도 눌린다.

워크플로가 순서대로 하고, 어느 단계든 실패하면 그 자리에서 멈춘다:

1. **버전 정합** — 입력 버전 = CHANGELOG 최상단 = 문서 CDN 태그 (`release.js --pre`)
2. **이미 나간 버전인지** — 태그 존재 검사
3. **lint · e2e · smoke** — 통과해야만 나간다 (`ci.yml` 과 같은 3종)
4. **태그 + Release 발행** — `gh release create` 가 태그를 함께 만든다. 본문은 `release.js --notes` 가 CHANGELOG 절에서 뽑는다
5. **jsDelivr 퍼지** — `@태그` 와 `@0`
6. **실물 검증** — 고정 태그 200 · `@0` 재해석 · **문서가 가리키는 주소가 실제로 열리는지** (`release.js --verify`)

로컬 경로(`node scripts/release.js --apply`)는 그대로 두었고, 같은 검사를 공유한다. 둘 중 무엇으로 내든 보는 것은 같다.

## 왜 6번이 핵심인가

이번에 버전 문자열만 올리고 태그를 안 만든 상태로 문서가 `@v0.19.2` 를 가리켰다. 그 주소는 404 였고, SKILL.md 를 읽은 AI 가 그대로 심었다면 프로토타입에서 조용히 아무것도 안 떴을 것이다.

lint 는 이걸 못 잡는다 — 헤더·배지·CHANGELOG·문서 태그가 *서로 같은지*만 보지 그 태그가 *실재하는지*는 보지 않는다(의존성 0 정적 검사라 네트워크를 쓰지 않는다). 그 구멍을 릴리스 단계에서 막는다.

## 변경

| 파일 | 내용 |
|---|---|
| `.github/workflows/release.yml` | 신규 — `workflow_dispatch` 릴리스 파이프라인 |
| `scripts/release.js` | CI 용 모드 추가: `--pre`(버전 정합만) · `--verify`(실물만) · `--notes`(릴리스 본문) · `--expect`(요청 버전 대조) |
| `AGENTS.md` | 릴리스 절차에 A(Actions 버튼) / B(로컬) 두 경로 · 구조 표에 워크플로 |

`workflow_dispatch` 입력은 셸에 직접 끼워 넣지 않고 `env` 로 넘긴다(인젝션 방지). `permissions: contents: write` 를 명시했다.

## 확인한 것

- 워크플로 YAML 파싱 정상 (`release` job · `workflow_dispatch` 트리거)
- `--pre --expect v0.19.2` → 통과 / `--expect v0.99.9` → 불일치로 exit 1
- `--notes` 가 CHANGELOG v0.19.2 절을 그대로 뽑는다
- lint 통과 · e2e 148 PASS/0 FAIL · smoke 는 `demo.html` 1건 (샌드박스가 외부 이미지를 막아서 — 이 변경 전 HEAD 에서도 동일 재현)
- 라이브러리는 건드리지 않았다. CHANGELOG 항목도 넣지 않았다 — 여기서 버전을 올리면 문서가 다시 미출시 태그를 가리키게 되므로, 다음 릴리스 항목에 함께 적는다

## 머지 후 한 번 필요할 수 있는 설정

조직/저장소 설정에서 Actions 토큰이 read-only 로 잠겨 있으면 태그·Release 생성이 403 이 난다. **Settings → Actions → General → Workflow permissions** 를 "Read and write" 로 한 번 열어주면 된다.

## 참고

e2e 를 5회 돌리는 동안 1회 `147 PASS / 1 FAIL` 이 나왔고 이후 4회는 모두 `148/0` 이었다. 요약만 캡처해 어느 케이스인지는 특정하지 못했다. 릴리스가 e2e 에 걸리므로, 재현되면 별도로 잡는 게 좋겠다 — 워크플로에 자동 재시도는 넣지 않았다(진짜 실패를 가린다).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2KwvLzGYN4kwcHEfuk74T)_